### PR TITLE
ci: fix node version for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           registry-url: https://registry.npmjs.org/
-          node-version: 16
+          node-version: 18
 
       # Install pnpm
       - uses: pnpm/action-setup@v2


### PR DESCRIPTION
The nodejs version >=18 is required by semantic-release 