### PR TITLE
fix: keypress is not called on first time

### DIFF
--- a/docs/public/demo.js
+++ b/docs/public/demo.js
@@ -117,6 +117,10 @@ function createTerminal(target) {
         term.focus();
     }
 
+    term.on('keypress', event => {
+        console.debug(['keypress', event.key]);
+    })
+
     // user input handler
     term.on("data", async input => {
 


### PR DESCRIPTION
Hi Henry, hope you're doing well!

I found a small bug: `keypress` event is not triggered the first time, even though the input is correctly registered in the buffer.

[keypress-event.webm](https://github.com/henryhale/xterminal/assets/10469299/d80003b1-8d25-44ab-933b-459d83ca6d7b)

I am opening this PR to provide the reproduction code. If reproduction code is correct, I will try to fix it, unless you already have a solution in mind.

Thanks!