### PR TITLE
fix: trigger keypress event on every key pressed

### DIFF
--- a/source/input/index.ts
+++ b/source/input/index.ts
@@ -17,7 +17,7 @@ export default class XInputComponent
     extends Disposable
     implements IInputInterface
 {
-    private el: HTMLInputElement;
+    public readonly el: HTMLInputElement;
     private data: IReactive<string>;
     private ptr: IReactive<number>;
     private isActive: IReactive<boolean>;
@@ -83,6 +83,7 @@ export default class XInputComponent
 
         this.register(
             addEvent(this.el, "keydown", (ev: KeyboardEvent) => {
+                ev.stopImmediatePropagation();
                 const value = this.data.value;
                 if (ev.key === ENTER_KEY) {
                     if (this.el) this.el.value = "";


### PR DESCRIPTION
The `keypress` event was not triggered if the input was previously blurred e.g. on the first key stroke after blur or page load.

Previously found by [Enzo Notario](https://github.com/enzonotario) at [#11]