### PR TITLE
ci: update release.yml, bump pnpm version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 7
+          version: 8
           run_install: false
 
       # Setup pnpm store


### PR DESCRIPTION
GitHub workflow failed to install deps with pnpm v7

Check out:
=>  https://github.com/orgs/pnpm/discussions/6633