### PR TITLE
fix(docs): update base url prefix

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitepress'
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
-  base: '/xterminal/',
+  base: '/',
 
   // metadata
   lang: 'en-US',


### PR DESCRIPTION
- Docs site broken over base url for assets 